### PR TITLE
Add table_whitelist configuration option

### DIFF
--- a/lib/mini_record/configuration.rb
+++ b/lib/mini_record/configuration.rb
@@ -13,11 +13,12 @@ module MiniRecord
   end
 
   class Configuration
-    attr_accessor :destructive, :raise_on_destructive_change_needed
+    attr_accessor :destructive, :raise_on_destructive_change_needed, :table_whitelist
 
     def initialize
       @destructive = true
       @raise_on_destructive_change_needed = false
+      @table_whitelist = []
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -41,13 +41,13 @@ class ActiveRecord::Base
     def auto_upgrade!(*args)
       ActiveRecord::Base.logs = StringIO.new
       ActiveRecord::Base.logger = Logger.new(ActiveRecord::Base.logs)
-      #silence_stream(STDERR) { super }
+      silence_stream(STDERR) { super }
     end
 
     def auto_upgrade_dry
       ActiveRecord::Base.logs = StringIO.new
       ActiveRecord::Base.logger = Logger.new(ActiveRecord::Base.logs)
-     # silence_stream(STDERR) { super }
+      silence_stream(STDERR) { super }
     end
   end
 end # ActiveRecord::Base


### PR DESCRIPTION
This is used to specify tables that we do not want to have automatically
dropped by MiniRecord when destructive is on.